### PR TITLE
New spec without session persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Random assignment of percentages MUST follow this criteria:
 
 - Key = take the input session ID and concatenate it with the flag's timestamp
 - Hash = use the previous string as key for computing a Murmur3 (32b) hash
-- Mod = Take the modulo of the division of the hash by 100
+- Mod = take the modulo of the division of the hash by 100
 - Consider the rollout expression if Mod < percentage
 
 ## Client Operations

--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
-# Tog
+# Tog Spec (v0.3)
 
 Tog (short for toggle) is a framework for clients and servers to converse about feature flags over Redis.
 
-- [Tog](#tog)
+- [Tog Spec (v0.3)](#tog-spec-v03)
   - [Concepts](#concepts)
     - [Flags](#flags)
-    - [Sessions](#sessions)
     - [Rollout strategies](#rollout-strategies)
   - [Client Operations](#client-operations)
     - [List flags](#list-flags)
     - [Get a flag](#get-a-flag)
+    - [Save a flag](#save-a-flag)
+    - [Delete a flag](#delete-a-flag)
     - [List a session's flags](#list-a-sessions-flags)
   - [Ecosystem](#ecosystem)
 
@@ -19,15 +20,22 @@ Tog (short for toggle) is a framework for clients and servers to converse about 
 
 A flag and its current value.
 
-**Type**: value
-**Key**: `tog2:flag:{namespace}:{flag_name}`
+**Type**: Hash Map
+**Key**: `tog3:flags:{namespace}`
+**Field**: `{name}`
 **Value**:
+
 ```json
 {
   "description": "Sets the call-to-action button color to blue",
+  "timestamp": 1590748359,
   "rollout": [
     {
       "percentage": 30,
+      "value": true
+    },
+    {
+      "traits": ["early_adopter"],
       "value": true
     },
     {
@@ -37,56 +45,53 @@ A flag and its current value.
 }
 ```
 
-### Sessions
-
-A hash of flag values for a session.
-
-**Type**: hash
-**Key**: `tog2:session:{namespace}:{session_id}`
-**Value**: 
-```json
-{
-    "<flag-one>": true,
-    "<flag-two>": false
-}
-```
-
 ### Rollout strategies
 
 If multiple strategies are defined for one rollout option, they will be applied with the AND operator. If no rollout rule is matched, then the fallback value for the flag is `false`.
 
-* `percentage`: will randomly assign the value to X percent of the sessions. Example:
-  * `{ "percentage": 30 }`
-* `tags`: will assign the value when the session's tags match all of the rollout tags. Example:
-  * `{ "match": { "domain": "escale.com.br" } }`
+- `percentage`: will randomly assign the value to X percent of the sessions. Example:
+  - `{ "percentage": 30 }`
+- `traits`: will assign the value when the session's traits match all of the rollout's traits. Example:
+  - `{ "traits": ["early_adopter"] }`
 
+Random assignment of percentages MUST follow this criteria:
+
+- Key = take the input session ID and concatenate it with the flag's timestamp
+- Hash = use the previous string as key for computing a Murmur3 (32b) hash
+- Mod = Take the modulo of the division of the hash by 100
+- Consider the rollout expression if Mod < percentage
 
 ## Client Operations
 
-A client implementation MAY adopt a memory cache for a namespace's flag list. If it chooses to do so, it MUST subscribe to changes and clear its cache either when notified or reconnected.
+A client implementation MAY adopt a memory cache for a namespace's flag list, in which case it must subscribe to `tog3:namespace-changed` to clear the cache when a change happens.
 
 ### List flags
 
-1. `KEYS tog2:flag:{namespace}:*`
-2. `MGET {key_1} {key_2} {key_n}`
+1. `HGETALL tog3:flags:{namespace}`
 
 ### Get a flag
 
-1. Try to find a previously listed flag from cache
-2. If not found or not connected, return a default value
+1. `HGET tog3:flags:{namespace} {name}`
+
+### Save a flag
+
+1. `HSET tog3:flags:{namespace} {name} {flag-json}`
+2. `PUBLISH tog3:namespace-changed {namespace}`
+
+### Delete a flag
+
+1. `HDEL tog3:flags:{namespace} {name}`
+2. `PUBLISH tog3:namespace-changed {namespace}`
 
 ### List a session's flags
 
-1. `GET tog2:session:{namespace}:{session_id}`; if found, return it
-2. List flags
-3. For each flag, apply its rollout rules to figure out its state
-4. `SET tog2:session:{namespace}:{session_id} {session-json}` with the picked values
-
+1. List flags
+2. For each flag, apply its rollout rules to figure out its state
 
 ## Ecosystem
 
-* Clients:
-  * Node.js: [`tog-node`](https://github.com/escaletech/tog-node)
-* [Management server](https://github.com/escaletech/tog-management-server): server application that provides management of flags and experiments. Best used with Tog CLI.
-* [Session server](https://github.com/escaletech/tog-session-server): server application that provides an endpoint for fetching sessions
-* [CLI](https://github.com/escaletech/tog-cli): command-line tool that interacts with the management server to update flags and experiments
+- Clients:
+  - Node.js: [`tog-node`](https://github.com/escaletech/tog-node)
+- [Management server](https://github.com/escaletech/tog-management-server): server application that provides management of flags and experiments. Best used with Tog CLI.
+- [Session server](https://github.com/escaletech/tog-session-server): server application that provides an endpoint for fetching sessions
+- [CLI](https://github.com/escaletech/tog-cli): command-line tool that interacts with the management server to update flags and experiments


### PR DESCRIPTION
## What this solves

This solves a few different issues that were bugging me:
* `KEYS` shouldn't be used in production, ever
  * **Solution**: flags are stored in a namespace's hash map, as they should've been from the start
* Sessions were not atomic, meaning that there was always a possibility of them being computed twice in parallel with different results
  * **Solution**: sessions are always computed in memory in a deterministic way, and are never persisted
* There was no clear way to expire a flag in sessions, and its duration seemed too arbitrary
  * **Solution**: by saving a flag, its salt (the timestamp) changes, forcing new random results for it

## Why is this a breaking change?
* Sessions don't have explicit TTL anymore
* Flags persistence changed

## The break is not big
Even though the persistence and session resolution have changed, their structre hasn't, so the ecosystem APIs can keep the same usage.